### PR TITLE
Direct the reader to the Docs TODO List instead of the wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 
             <h3>How can I help?</h3>
             <p>Citra's source is hosted on <a href="https://github.com/citra-emu/citra">GitHub</a>, which is a platform where developers can come together on a project, submitting pull requests with code changes.</p>
-            <p>You probably want to check out the <a href="https://github.com/citra-emu/citra/blob/master/CONTRIBUTING.md">contributor's guide</a> and the <a href="https://github.com/citra-emu/citra/wiki/Developer-Information">developer information</a>. You can look to the <a href="https://github.com/citra-emu/citra/wiki/Roadmap">project roadmap</a> for ideas.</p>
+            <p>You probably want to check out the <a href="https://github.com/citra-emu/citra/blob/master/CONTRIBUTING.md">contributor's guide</a> and the <a href="https://github.com/citra-emu/citra/wiki/Developer-Information">developer information</a>. You can look to the <a href="https://docs.google.com/document/d/1SWIop0uBI9IW8VGg97TAtoT_CHNoP42FzYmvG1F4QDA">TODO list</a> for ideas.</p>
             <p>You can also chat with us at #citra on <a href="https://webchat.freenode.net">freenode</a>. We'll take all the help we can get!</p>
             <p>If you can't contribute any code, we also appreciate <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K899FANUJ2ZXW">donations</a> (no matter how small!), which we would use to buy systems and games to test with, or pay for infrastructure and web costs.</p>
 


### PR DESCRIPTION
The TODO list document was more up-to-date anyway.